### PR TITLE
Show where pointer options go in the YAML config

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Simply add the extension to the list of reveal plugins like:
 title: My Presentation
 format:
     revealjs: default
+    pointer:
+      - # set pointer configuration options here
 revealjs-plugins:
   - pointer
 ```


### PR DESCRIPTION
Thanks for this plugin! I was confused about where the pointer options key goes from reading the README. At first I thought it went under the `revealjs-plugins` key:

```yaml
title: My Presentation
format:
    revealjs: default
revealjs-plugins:
  pointer:
    option: value
```

which did not work.

The example document has the correct config, but it may be helpful to have an example with the location of the config options in the README.